### PR TITLE
Allow any version of Google Authenticator < 3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
   "require": {
     "mageplaza/module-core": "^1.4.5",
     "sinergi/browser-detector": "*",
-    "sonata-project/google-authenticator": "2.0.0"
+    "sonata-project/google-authenticator": "^2.0.0"
   },
   "type": "magento2-module",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "license": "proprietary",
   "authors": [
     {


### PR DESCRIPTION
Have tested this without issue; not sure why they locked it at 2.0.0.